### PR TITLE
Added Additional SQL Generation for Pk, FK, Not Null, Unique for Edits to existing Table Columns

### DIFF
--- a/client/permissiveFn.js
+++ b/client/permissiveFn.js
@@ -850,10 +850,10 @@ let tableName = "public.accounts"
 */
 export default function permissiveColumnCheck(ColBeforeChange, ColAfterChange, tableName, TableBeforeChange) {
 
-    console.log(ColAfterChange);
-    console.log(ColBeforeChange);
-    console.log(tableName);
-    console.log(TableBeforeChange);
+    console.log('---------->',ColAfterChange);
+    console.log('---------->',ColBeforeChange);
+    console.log('---------->',tableName);
+    console.log('---------->',TableBeforeChange);
   
     
 // constraints
@@ -877,12 +877,12 @@ let impactedTable = TableBeforeChange[tableName];
    //check Col Name Change Before vs. After
    if (ColAfterChange.column !== ColBeforeChange.column)
    {
-        
+        console.log("Column Name check")
        //trim column name for whitespaces
        ColAfterChange.column = ColAfterChange.column.trim();
        
         // first check if the column name is empty
-        if (ColAfterChange.column == null || ColAfterChange == undefined)
+        if (ColAfterChange.column == null || ColAfterChange.column == undefined)
         return({status: "failed", errorMsg:"Must not have empty column name"})
 
        //validate Name against restricted Column Names
@@ -892,36 +892,41 @@ let impactedTable = TableBeforeChange[tableName];
         return ({status: "failed", errorMsg:"Restricted Column Name Violation to Table"});
        }
 
-       //regex check valid Column Name against Postgres ruleset. 
+       //regex check valid Column Name against Postgres ruleset.
+      
        const regex =  /^[a-zA-Z_][a-zA-Z0-9_]*$/;
-       console.log(ColAfterChange.column.match(regex));
-       console.log(ColAfterChange.column);
-       if (ColAfterChange.column.match(regex) == null )
-       { console.log("failed")
+       //console.log(ColAfterChange.column.match(regex));
+     
+    
+       if (ColAfterChange.column.match(regex)[0] !==  ColAfterChange.column)
+       { console.log("failed-------------->in Regex");
         return ({status: "failed", errorMsg:"Postgres restricted column name violation"});
        }
 
        //check Column name against all other columns in table. If name already exist
        //in table, flag as error in fn response
+
+       /*
        for (let colNames in impactedTable)
-       {
-    if (impactedTable[colNames].Name.toUpperCase().indexOf(ColAfterChange.column.toUpperCase())!== -1) 
+       { console.log('in impacted Table comparasion', impactedTable);
+    if (impactedTable[colNames].Name.toUpperCase() == ColAfterChange.column.toUpperCase()) 
        {
         console.log(impactedTable[colNames].Name)
-        console.log(ColAfterChange.column)
+        console.log(ColAfterChange.column);
         return ({status: "failed", errorMsg:"Postgres restriction. Duplicate column name"});
        }
        
-      
+   
     
        }
+          */
        objChangeSet.column = {status: true, newValue:ColAfterChange.column, oldValue:ColBeforeChange.column}
        let nameQuery = "ALTER TABLE ".concat(tableName).concat(" RENAME COLUMN ").concat(ColBeforeChange.column).concat(" TO ").concat(ColAfterChange.column).concat(";")
        querySet.push({type:'single', query:nameQuery});
 
-       console.log(querySet)
+       console.log(querySet);
    }
-
+    console.log('after the column is done', querySet)
    //check constraint col for changes. This should be an obj of objs, so we will code both
    //type for now
    if (typeof(ColAfterChange.constraint) == "string")
@@ -963,7 +968,7 @@ let impactedTable = TableBeforeChange[tableName];
 
 
         }
-        
+   
        console.log(newConstObj.constraint)
 
         for (let constr in newConstObj.constraint) {

--- a/client/permissiveFn.js
+++ b/client/permissiveFn.js
@@ -877,24 +877,15 @@ let impactedTable = TableBeforeChange[tableName];
    //check Col Name Change Before vs. After
    if (ColAfterChange.column !== ColBeforeChange.column)
    {
-<<<<<<< HEAD
-        console.log("Column Name check")
-=======
         
         console.log("hey",ColAfterChange)
         console.log("ho",ColBeforeChange)
->>>>>>> 4f726d5e69b75802eab26b2749ab08579f0e9314
        //trim column name for whitespaces
        ColAfterChange.column = ColAfterChange.column.trim();
        
         // first check if the column name is empty
-<<<<<<< HEAD
-        if (ColAfterChange.column == null || ColAfterChange.column == undefined)
-        return({status: "failed", errorMsg:"Must not have empty column name"})
-=======
         if (ColAfterChange.column == null || ColAfterChange == undefined)
         return([{status: "failed", errorMsg:"Must not have empty column name"}])
->>>>>>> 4f726d5e69b75802eab26b2749ab08579f0e9314
 
        //validate Name against restricted Column Names
        if (restrictedColNames[ColAfterChange.column.toUpperCase()])
@@ -906,33 +897,6 @@ let impactedTable = TableBeforeChange[tableName];
        //regex check valid Column Name against Postgres ruleset.
       
        const regex =  /^[a-zA-Z_][a-zA-Z0-9_]*$/;
-<<<<<<< HEAD
-       //console.log(ColAfterChange.column.match(regex));
-     
-    
-       if (ColAfterChange.column.match(regex)[0] !==  ColAfterChange.column)
-       { console.log("failed-------------->in Regex");
-        return ({status: "failed", errorMsg:"Postgres restricted column name violation"});
-       }
-
-       //check Column name against all other columns in table. If name already exist
-       //in table, flag as error in fn response
-
-       /*
-       for (let colNames in impactedTable)
-       { console.log('in impacted Table comparasion', impactedTable);
-    if (impactedTable[colNames].Name.toUpperCase() == ColAfterChange.column.toUpperCase()) 
-       {
-        console.log(impactedTable[colNames].Name)
-        console.log(ColAfterChange.column);
-        return ({status: "failed", errorMsg:"Postgres restriction. Duplicate column name"});
-       }
-       
-   
-    
-       }
-          */
-=======
     //    console.log(ColAfterChange.column.match(regex));
     //    console.log(ColAfterChange.column);
     //    if (ColAfterChange.column.match(regex) == null )
@@ -955,7 +919,6 @@ let impactedTable = TableBeforeChange[tableName];
     //    }
 
     
->>>>>>> 4f726d5e69b75802eab26b2749ab08579f0e9314
        objChangeSet.column = {status: true, newValue:ColAfterChange.column, oldValue:ColBeforeChange.column}
        let nameQuery = "ALTER TABLE ".concat(tableName).concat(" RENAME COLUMN ").concat(ColBeforeChange.column).concat(" TO ").concat(ColAfterChange.column).concat(";")
        querySet.push({type:'single', query:nameQuery});

--- a/client/permissiveFn.js
+++ b/client/permissiveFn.js
@@ -3,6 +3,22 @@
 2. DIscuss how we might want to handle request to change datatype
 
 */
+// constraints
+const objConstraints = { "UNIQUE": true, "PRIMARY KEY": true, "FOREIGN KEY": true, "CHECK": true, "EXCLUSION": true, "NOT NULL": true};
+
+
+// restricted col names
+const restrictedColNames = { "ALL": true, "ANALYSE": true, "ANALYZE": true, "AND": true, "ANY": true, "ARRAY": true, "AS": true, "ASC": true, "ASYMMETRIC": true, "BOTH": true, "CASE": true, "CAST": true, "CHECK": true, "COLLATE": true, "COLUMN": true, "CONSTRAINT": true, "CREATE": true, "CURRENT_CATALOG": true, "CURRENT_DATE": true, "CURRENT_ROLE": true, "CURRENT_TIME": true, "CURRENT_TIMESTAMP": true, "CURRENT_USER": true, "DEFAULT": true, "DEFERRABLE": true, "DESC": true, "DISTINCT": true, "DO": true, "ELSE": true, "END": true, "EXCEPT": true, "FALSE": true, "FETCH": true, "FOR": true, "FOREIGN": true, "FROM": true, "GRANT": true, "GROUP": true, "HAVING": true, "IN": true, "INITIALLY": true, "INTERSECT": true, "INTO": true, "LATERAL": true, "LEADING": true, "LIMIT": true, "LOCALTIME": true, "LOCALTIMESTAMP": true, "NOT": true, "NULL": true, "OFFSET": true, "ON": true, "ONLY": true, "OR": true, "ORDER": true, "PLACING": true, "PRIMARY": true, "REFERENCES": true, "RETURNING": true, "SELECT": true, "SESSION_USER": true, "SOME": true, "SYMMETRIC": true, "TABLE": true, "THEN": true, "TO": true, "TRAILING": true, "true": true, "UNION": true, "UNIQUE": true, "USER": true, "USING": true, "VARIADIC": true, "WHEN": true, "WHERE": true, "WINDOW": true, "WITH": true};
+
+
+
+
+
+
+
+
+
+
 
 /*
 let TableBeforeChange = {
@@ -856,14 +872,6 @@ export default function permissiveColumnCheck(ColBeforeChange, ColAfterChange, t
     console.log('---------->',TableBeforeChange);
   
     
-// constraints
-const objConstraints = { "UNIQUE": true, "PRIMARY KEY": true, "FOREIGN KEY": true, "CHECK": true, "EXCLUSION": true, "NOT NULL": true}
-
-
-// restricted col names
-const restrictedColNames = { "ALL": true, "ANALYSE": true, "ANALYZE": true, "AND": true, "ANY": true, "ARRAY": true, "AS": true, "ASC": true, "ASYMMETRIC": true, "BOTH": true, "CASE": true, "CAST": true, "CHECK": true, "COLLATE": true, "COLUMN": true, "CONSTRAINT": true, "CREATE": true, "CURRENT_CATALOG": true, "CURRENT_DATE": true, "CURRENT_ROLE": true, "CURRENT_TIME": true, "CURRENT_TIMESTAMP": true, "CURRENT_USER": true, "DEFAULT": true, "DEFERRABLE": true, "DESC": true, "DISTINCT": true, "DO": true, "ELSE": true, "END": true, "EXCEPT": true, "FALSE": true, "FETCH": true, "FOR": true, "FOREIGN": true, "FROM": true, "GRANT": true, "GROUP": true, "HAVING": true, "IN": true, "INITIALLY": true, "INTERSECT": true, "INTO": true, "LATERAL": true, "LEADING": true, "LIMIT": true, "LOCALTIME": true, "LOCALTIMESTAMP": true, "NOT": true, "NULL": true, "OFFSET": true, "ON": true, "ONLY": true, "OR": true, "ORDER": true, "PLACING": true, "PRIMARY": true, "REFERENCES": true, "RETURNING": true, "SELECT": true, "SESSION_USER": true, "SOME": true, "SYMMETRIC": true, "TABLE": true, "THEN": true, "TO": true, "TRAILING": true, "true": true, "UNION": true, "UNIQUE": true, "USER": true, "USING": true, "VARIADIC": true, "WHEN": true, "WHERE": true, "WINDOW": true, "WITH": true}
-
-
 
 
 //get current table involved with change. 
@@ -875,7 +883,14 @@ let impactedTable = TableBeforeChange[tableName];
    let err = {} //error response handler
 
    //check Col Name Change Before vs. After
-   if (ColAfterChange.column !== ColBeforeChange.column)
+
+   if (ColAfterChange.isNew)
+   {
+     let UQueryNewCol =  'ALTER TABLE ' + tableName +
+    ' ADD ' + ColAfterChange.column + ' ' + ColAfterChange.type;
+    querySet.push(UQueryNewCol);
+   }
+   else (ColAfterChange.column !== ColBeforeChange.column);
    {
         
         console.log("hey",ColAfterChange)
@@ -1123,6 +1138,6 @@ let impactedTable = TableBeforeChange[tableName];
    
    console.log(querySet);
    return querySet; 
-   
-}
+} 
+ 
 

--- a/server/controllers/dataController.js
+++ b/server/controllers/dataController.js
@@ -39,6 +39,55 @@ const writeSchema = async (command) => {
   }
 };
 
+dataController.testDrop = (req, res, next) => {
+let uri = 'postgres://cwoalfud:jqrPGXvWd8vqZydnDinBiWy1gS4C_a9J@arjuna.db.elephantsql.com/cwoalfud';
+
+/*
+  let querytest = "DO $$ DECLARE row record; BEGIN FOR row IN SELECT table_constraints.constraint_name, table_constraints.table_name FROM information_schema.table_constraints INNER JOIN information_schema.key_column_usage ON key_column_usage.table_name = information_schema.table_constraints.table_name WHERE table_constraints.table_schema = 'public' AND table_constraints.table_name='films' AND constraint_type='UNIQUE' AND key_column_usage.column_name= 'title' LOOP EXECUTE 'ALTER TABLE ' || row.table_name || ' DROP CONSTRAINT ' || row.constraint_name; END LOOP; END;$$";
+*/
+
+const ColAfterChange = { 
+  "column": "title",
+  "constraint": " ",
+  "fk": true,
+  "id": "title",
+  "isNew": false,
+  "pk": false,
+  "type": "integer",
+  
+       "References": 
+              {
+                  "PrimaryKeyName": "_id",
+                  "ReferencesPropertyName": "person_id integer NOT NULL",
+                  "PrimaryKeyTableName": "public.people",
+                  "ReferencesTableName": "public.people_in_films",
+                  "IsDestination": false
+              }
+          
+  
+}
+
+let tableName = "public.films";
+
+const queryForeign =   'alter table ' + tableName + ' alter column ' + ColAfterChange.column + ' set not null;';
+
+ //querySet.push( {type:'single', query:queryForeign});
+
+/*
+  const pool = new Pool({
+    connectionString: uri,
+  });
+
+
+  pool.query(querytest).then(data => {
+    return next();
+  });
+
+*/
+res.locals.testresponse = queryForeign; 
+next();
+};
+
 //getSchema controller allows the user
 dataController.getSchema = (req, res, next) => {
   // let result = null;

--- a/server/controllers/dataController.js
+++ b/server/controllers/dataController.js
@@ -57,7 +57,6 @@ const writeSchema =  async (command) => {
 //getSchema controller allows the user 
 dataController.getSchema = (req, res, next) => {
 
-  
     // let result = null; 
     // console.log("running getSchema controller...");
     // const hostname = req.body.hostname;
@@ -90,7 +89,7 @@ dataController.getSchema = (req, res, next) => {
 
 
 
-fs.readFile(path.join(__dirname, '../db_schemas/vjcmcautvjcmcaut1657127402.sql'), 'utf8', (error, data) => {
+fs.readFile(path.join(__dirname, '../db_schemas/twvoyfdatwvoyfda1656611693.sql'), 'utf8', (error, data) => {
   if (error) 
     {
       console.error(`error- in FS: ${error.message}`);
@@ -100,9 +99,9 @@ fs.readFile(path.join(__dirname, '../db_schemas/vjcmcautvjcmcaut1657127402.sql')
     }
   const result = parseSql(data);
    //console.log(result);
-   for (let records in result)
+  
    //console.log('instance of table', result[records]);
-  res.locals.testdata = result;
+  res.locals.data = result;
   next();
 
   });
@@ -112,8 +111,8 @@ fs.readFile(path.join(__dirname, '../db_schemas/vjcmcautvjcmcaut1657127402.sql')
   //usable format for front-end
 dataController.objSchema = (req, res, next) => {
 
-  
-  let testdata = res.locals.testdata;
+  console.log(res.locals.data)
+  let testdata = res.locals.data;
   let results = {};
   //iterate through the testdata Array
     //Grab name property for each element of array - Table Name 

--- a/server/controllers/dataController.js
+++ b/server/controllers/dataController.js
@@ -47,13 +47,14 @@ let uri = 'postgres://cwoalfud:jqrPGXvWd8vqZydnDinBiWy1gS4C_a9J@arjuna.db.elepha
 */
 
 const ColAfterChange = { 
-  "column": "title",
+  "column": "title_new",
   "constraint": " ",
   "fk": true,
+  "type": "integer",
   "id": "title",
   "isNew": false,
   "pk": false,
-  "type": "integer",
+  
   
        "References": 
               {
@@ -67,9 +68,10 @@ const ColAfterChange = {
   
 }
 
-let tableName = "public.films";
+let tableName = "public.alphabet";
 
-const queryForeign =   'alter table ' + tableName + ' alter column ' + ColAfterChange.column + ' set not null;';
+  let UQueryNewCol =  'ALTER TABLE ' + tableName +
+' ADD ' + ColAfterChange.column + ' ' + ColAfterChange.type;
 
  //querySet.push( {type:'single', query:queryForeign});
 
@@ -84,7 +86,7 @@ const queryForeign =   'alter table ' + tableName + ' alter column ' + ColAfterC
   });
 
 */
-res.locals.testresponse = queryForeign; 
+res.locals.testresponse = UQueryNewCol; 
 next();
 };
 

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -34,8 +34,7 @@ router.post(
    controller.objSchema,
   (req, res) => {
     console.log('called');
-    // res.status(200).json(dummydata);
-    // res.status(200).json(res.locals.data);
+    ;
     res.status(200).json(res.locals.result);
   }
 );

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -28,6 +28,11 @@ router.get('/getAllSchemas', controller.getAllSchemas, (req, res) => {
   res.status(200).json({ ok: 'ok' });
 });
 
+router.get('/testDrop', controller.testDrop, (req, res) => {
+  res.status(200).json(res.locals.testresponse);
+});
+
+
 router.post(
   '/getSchema',
    controller.getSchema,


### PR DESCRIPTION
- Utilized Do procedural function postgres block to retrieve constraint_names for specific columns and tables, to run query to drop constraints as specified by user. 
- Added provisions for inserting new foreign key assuming references object includes the following within column object: 
"References": 
              {
                  "PrimaryKeyName": "PrimaryKeyName",
                  "ReferencesPropertyName": "references_col_name ",
                  "PrimaryKeyTableName": "<schema>.<tablename>",
                  "ReferencesTableName": "<schema>.<tablename>",
              }
Reference Object for new column contains only reference object for the new FK, not other references that may exist. 

- Added bench setup in dataController (testDrop) for simulating output from portions of permissive function. 
